### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -1,4 +1,6 @@
 name: Proof HTML
+permissions:
+  contents: read
 on:
   push:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Pearl1981/demo-repository/security/code-scanning/6](https://github.com/Pearl1981/demo-repository/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's purpose (processing HTML files), it likely only needs read access to the repository contents. We will set `contents: read` as the permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
